### PR TITLE
fix: color now works in filter view

### DIFF
--- a/api/records/GraphRecords.js
+++ b/api/records/GraphRecords.js
@@ -56,6 +56,8 @@ class GraphRecords {
           rels.push(rel);
         }
         node.defTypeTitle = nodeType;
+        node.defType = nodeType;
+
         nodes.push(node);
       });
     });
@@ -73,6 +75,8 @@ class GraphRecords {
           delete rel.updated;
           rel.id = file.slice(0, -5);
           rel.defTypeTitle = relType;
+          rel.defType = relType;
+
           rels.push(rel);
         });
       });

--- a/public/components/graph/Graph.js
+++ b/public/components/graph/Graph.js
@@ -476,19 +476,19 @@ async function Graph(view) {
       .on("contextmenu", rightClicked);
 
     function setColour(d) {
-      if (d.defTypeTitle === "propType") {
+      if (d.defType === "propType") {
         return "#89A7B0";
-      } else if (d.defTypeTitle === "propKey") {
+      } else if (d.defType === "propKey") {
         return "#E9BD60";
-      } else if (d.defTypeTitle === "propVal") {
+      } else if (d.defType === "propVal") {
         return "#C3B65B";
-      } else if (d.defTypeTitle === "configDef") {
+      } else if (d.defType === "configDef") {
         return "#70AA6C";
-      } else if (d.defTypeTitle === "configObj") {
+      } else if (d.defType === "configObj") {
         return "#32BCC3";
-      } else if (d.defTypeTitle === "typeData") {
+      } else if (d.defType === "typeData") {
         return "#E44167";
-      } else if (d.defTypeTitle === "instanceData") {
+      } else if (d.defType === "instanceData") {
         return "#A79587";
       }
     }


### PR DESCRIPTION
The nodes in the filter view were black instead of their own layer color. 

Reason: d3 was looking for the attribute "defTypeTitle" for each node, which is not outputed by the graphQL API (only "defType").

I added defType in the REST API so it outputs both defType and defTypeTitle. 

Ticket created:
- In graphQL API, change defType to defTypeTitle.