### PR TITLE
C2 72 all rels in treenode rels should be present in staterelations 

### DIFF
--- a/public/store/Store/Tree.js
+++ b/public/store/Store/Tree.js
@@ -86,9 +86,12 @@ Tree.prototype.fructify = function(dbNodes, layer){
 TreeNode.prototype.setRels = async function () {
     const relations = await queryRelations(this.id)
     relations.map( rel => {
-        if(this.rels.find(el => el.id === rel.id) === undefined) this.rels.push(rel)
-        if(State.relations.find(el => el.id === rel.id) === undefined) State.relations.push(rel)
-    } )
+        const stateRel = State.relations.find(stateRel => stateRel.id === rel.id)
+        if (stateRel === undefined) {
+            State.relations.push(rel)
+            this.rels.push(rel)
+        } else if (this.rels.find(rel => rel.id === stateRel.id) === undefined) this.rels.push(stateRel)
+    })
 }
 
 function getOtherIdInRel(rel, id){


### PR DESCRIPTION
When fetching the rels of a node, it also add this rels to State.relations.
Sometimes, depending on some if branching, the rel in treenode.rels would be a copy of the one in the state, instead of pointing to it.
this inconsistent behavior store a copy for no reason and could have led to troubles in the future.