### PR TITLE
C2 84 multiple selected profiles still shows up when unrelated porject is picked

### DIFF
--- a/public/components/filter/FilterBox.js
+++ b/public/components/filter/FilterBox.js
@@ -2,10 +2,11 @@ import {State} from "../../store/State.js";
 
 async function FilterBox() {
 
-  let nodes = State.treeOfNodes.tree
+  let tree = State.treeOfNodes.tree
+    await State.treeOfNodes.ensureInit()
 
   let nodeHtmlString = ``
-  nodes.forEach(node => {
+  tree.forEach(node => {
         nodeHtmlString += itemRow(node)
       }
   )

--- a/public/components/filter/filterFunctions.js
+++ b/public/components/filter/filterFunctions.js
@@ -23,8 +23,10 @@ export async function checkAll(event) {
     const treeNode = tree.getNodeById(input.id.substring(4))
     treeNode.isViewAllChecked = !treeNode.isViewAllChecked
     if (treeNode.isViewAllChecked) {
+        console.log("check all")
         treeNode.selectChildren()
     } else {
+        console.log("uncheck all")
         treeNode.deselectLineage()
     }
 

--- a/public/store/Store/Tree.js
+++ b/public/store/Store/Tree.js
@@ -109,13 +109,11 @@ function getOtherIdInRel(rel, id){
 }
 
 function createPseudoParentRel(parentId, childId){
-    const lineageRel = {
+    return {
         sourceId: childId,
         targetId: parentId,
         title:"has parent",
     }
-    console.log("pseudo parent rel created: " + JSON.stringify(lineageRel, null, 2))
-    return lineageRel
 }
 
 TreeNode.prototype.setChildrenVisibility = async function (tree) {

--- a/public/store/Store/Tree.js
+++ b/public/store/Store/Tree.js
@@ -77,7 +77,6 @@ TreeNode.prototype.deselectLineage = function(){
 
 TreeNode.prototype.selectChildren = function(){
     for(let child of this.children){
-        console.log("selecting child: " + child.title)
         child.selected = true
     }
 }
@@ -132,11 +131,9 @@ TreeNode.prototype.setChildrenVisibility = async function (tree) {
 
         if(otherChildrenSelectedIds.length === 0) continue
 
-        console.log("otherChildrenSelectedIds", otherChildrenSelectedIds)
         for(let child of this.children) {
             await child.extraFetch(tree)
             if (child.rels.find(rel => rel.parentId === visibleRel.id && otherChildrenSelectedIds.includes(getOtherIdInRel(rel, child.id))) === undefined) {
-                console.log("child hidden: " + child.title)
                 child.hidden = true
                 child.selected = false
             }

--- a/public/store/Store/Tree.js
+++ b/public/store/Store/Tree.js
@@ -189,6 +189,8 @@ Tree.prototype.shake = async function () {
         nodesOnThisLayer = nodesOnNextLayer
         nodesOnNextLayer = []
     }
+
+    this.setSelectedNodesData()
 }
 
 TreeNode.prototype.overview = function(){

--- a/public/views/Filter.js
+++ b/public/views/Filter.js
@@ -23,7 +23,7 @@ export default class Filter {
             return rel
         })
 
-        sessionStorage.setItem("filter", JSON.stringify([{nodes: tree.selectedNodesData , rels: tree.visibleRelations }]));
+        sessionStorage.setItem("filter", JSON.stringify([{nodes: tree.setSelectedNodesData() , rels: tree.visibleRelations }]));
 
         const mainAppNodes = await this.returnRenderFunc("filter")
         const filterBoxNodes = await FilterBox()

--- a/public/views/Filter.js
+++ b/public/views/Filter.js
@@ -23,7 +23,7 @@ export default class Filter {
             return rel
         })
 
-        sessionStorage.setItem("filter", JSON.stringify([{nodes: tree.setSelectedNodesData() , rels: tree.visibleRelations }]));
+        sessionStorage.setItem("filter", JSON.stringify([{nodes: tree.selectedNodesData , rels: tree.visibleRelations }]));
 
         const mainAppNodes = await this.returnRenderFunc("filter")
         const filterBoxNodes = await FilterBox()


### PR DESCRIPTION
List of nodes to display was not ultimately updated when queried by the filter view. It is now the case. It is likely to solve other bugs.