### PR TITLE
C2 85 when deslecting all parent is also deselected

### DIFF
--- a/public/components/filter/filterFunctions.js
+++ b/public/components/filter/filterFunctions.js
@@ -28,6 +28,8 @@ export async function checkAll(event) {
     } else {
         console.log("uncheck all")
         treeNode.deselectLineage()
+        treeNode.selected = true
+
     }
 
     await tree.shake()

--- a/public/store/Store/Tree.js
+++ b/public/store/Store/Tree.js
@@ -69,6 +69,7 @@ Tree.prototype.setSelectedNodesData = function(){
 TreeNode.prototype.deselectLineage = function(){
     if(this.selected === true) {
         this.selected = false
+        this.isViewAllChecked = false
         for (let child of this.children) {
             child.deselectLineage()
         }


### PR DESCRIPTION
Parent is no longer deselected when unchecking "all". Also the "all" of a node is now set to false when the node is deselected.