### PR TITLE
C2 76 newly created nodes should not be black

### DIFF
--- a/public/store/Actions.js
+++ b/public/store/Actions.js
@@ -47,6 +47,7 @@ class Actions {
       });
       const recordJson = await record.json();
       recordJson.defTypeTitle = defType.defTypeTitle;
+      recordJson.defType = defType.defTypeTitle;
       delete recordJson.created;
       delete recordJson.updated;
 


### PR DESCRIPTION
Fixed. when imported from db, nodes get a defType parameter setup. This param was not set up when received from the create function. It is now set (by cloning defTypeTitle).