### PR TITLE
C2 81 graph switch sometimes disappear

### DIFF
--- a/public/components/table/dataRendererHelper.js
+++ b/public/components/table/dataRendererHelper.js
@@ -118,7 +118,6 @@ export function setupToolBar(viewName, optionalAdditionalNodes) {
     "for": "flexSwitchCheckDefault",});
   switchLabel.innerHTML = "Table/Graph"
 
-  console.log("bob is here")
   switchInput.addEventListener("click", async (event, state) => {
     if(event.target.checked){
       document.querySelector("#app").innerHTML = ""

--- a/public/components/table/dataRendererHelper.js
+++ b/public/components/table/dataRendererHelper.js
@@ -117,7 +117,6 @@ export function setupToolBar(viewName, optionalAdditionalNodes) {
   const switchLabel = createHtmlElementWithData("label", { "class": "form-check-label",
     "for": "flexSwitchCheckDefault",});
   switchLabel.innerHTML = "Table/Graph"
-
   switchInput.addEventListener("click", async (event, state) => {
     if(event.target.checked){
       document.querySelector("#app").innerHTML = ""

--- a/public/components/table/dataRendererHelper.js
+++ b/public/components/table/dataRendererHelper.js
@@ -117,6 +117,8 @@ export function setupToolBar(viewName, optionalAdditionalNodes) {
   const switchLabel = createHtmlElementWithData("label", { "class": "form-check-label",
     "for": "flexSwitchCheckDefault",});
   switchLabel.innerHTML = "Table/Graph"
+
+  console.log("bob is here")
   switchInput.addEventListener("click", async (event, state) => {
     if(event.target.checked){
       document.querySelector("#app").innerHTML = ""

--- a/public/components/table/dataRendererHelper.js
+++ b/public/components/table/dataRendererHelper.js
@@ -111,7 +111,6 @@ export async function renderDataAsTable(viewName,
 
 export function setupToolBar(viewName, optionalAdditionalNodes) {
   document.querySelector("#toolBar").innerHTML = "";
-<<<<<<< HEAD
   const switchDiv = createHtmlElementWithData("div", { "class": "form-check form-switch d-flex p-3 justify-content-end" })
   const switchInput = createHtmlElementWithData("input", {
     "class": "form-check-input",
@@ -121,14 +120,6 @@ export function setupToolBar(viewName, optionalAdditionalNodes) {
     "class": "form-check-label",
     "for": "flexSwitchCheckDefault",
   });
-=======
-  const switchDiv = createHtmlElementWithData("div", { "class": "form-check form-switch" })
-  const switchInput = createHtmlElementWithData("input", { "class": "form-check-input",
-    "type": "checkbox", "role": "switch", "id": "flexSwitchCheckDefault", "checked":""})
-  const switchLabel = createHtmlElementWithData("label", { "class": "form-check-label",
-    "for": "flexSwitchCheckDefault",});
-  switchLabel.innerHTML = "Table/Graph"
->>>>>>> 0f0d5f511b56a58a712d1ce947c9916b6248d925
   switchInput.addEventListener("click", async (event, state) => {
     if (event.target.checked) {
       document.querySelector("#app").innerHTML = ""

--- a/public/store/Store/Tree.js
+++ b/public/store/Store/Tree.js
@@ -2,13 +2,13 @@ import {State} from "../State.js";
 import {queryDefinitions, queryNodeChildren, queryRelations} from "./dbStore.js";
 
 export function Tree() {
-    this.tree = null
+    this.tree = []
     this.visibleRelations = []
     this.selectedNodesData = []
 }
 
 Tree.prototype.ensureInit = async function () {
-    if(this.tree === null) {
+    if(this.tree.length === 0) {
     const defNodes = await queryDefinitions()
     this.tree = this.fructify(defNodes, 0)}
 }


### PR DESCRIPTION
fixed: tree not loaded was causing error, probably terminating function that would later init toolbar.
Problem related to tree loading could be avoided by having the tree as a class instead of a prototype (I believe)