### PR TITLE
chore: added hide/show icon that toggles

### DIFF
--- a/public/components/Icons.js
+++ b/public/components/Icons.js
@@ -1,0 +1,7 @@
+export const eyeFillShow = (moreClass = none, moreConfig = none) => {
+    return `<i class="bi bi-eye-fill ${moreClass}" ${moreConfig}></i>`
+} 
+
+export const eyeFillHide = (moreClass = none, moreConfig = none)  => {
+    return `<i class="bi bi-eye-slash-fill ${moreClass}" ${moreConfig}></i>`
+} 

--- a/public/components/filter/FilterBox.js
+++ b/public/components/filter/FilterBox.js
@@ -69,9 +69,4 @@ function itemRow(node){
     return mainRow
 }
 
-function toggleHideShow(node) {
-
-}
-
-
 export default FilterBox;

--- a/public/components/filter/FilterBox.js
+++ b/public/components/filter/FilterBox.js
@@ -1,4 +1,5 @@
 import {State} from "../../store/State.js";
+import { iconEye } from "./toggleHideShow.js";
 
 async function FilterBox() {
 
@@ -46,7 +47,6 @@ function itemRow(node){
             <input class="form-check-input" type="checkbox" value="" id="all_${node.id}" data-function="checkAll" ${ node.isViewAllChecked? "checked": ""}>
             <label class="form-check-label" for="all_${node.id}"> All</label>
             <br/>
-            
           `
       for(let child of node.children){
             childrenFrame += itemRow(child)
@@ -55,14 +55,23 @@ function itemRow(node){
       childrenFrame += `</ul>`
     }
 
+    const iconShow = `<div class="d-inline-block" id="toggleEyeContainer_${node.id}">${iconEye(node.id).show}</div>`
+  
+  
      let mainRow = `
+     <div id="form-check-input-container" class="d-inline-block" role="button">
           <input class="form-check-input" type="checkbox" value="" id="checkbox_${node.id}" data-function="checkFilter" ${ node.selected? "checked": ""}>
-          <label class="form-check-label" for="checkbox_${node.id}"> ${node.title}</label>
-          
+          <label class="form-check-label" for="checkbox_${node.id}"> ${node.title}</label> ${ node.selected? iconShow : ""}
+          </div>
           ${ childrenFrame }
      `
 
     return mainRow
 }
+
+function toggleHideShow(node) {
+
+}
+
 
 export default FilterBox;

--- a/public/components/filter/filterFunctions.js
+++ b/public/components/filter/filterFunctions.js
@@ -1,4 +1,3 @@
-
 import {State} from "../../store/State.js";
 import navigateTo from "../../helpers/navigateTo.js";
 

--- a/public/components/filter/filterFunctions.js
+++ b/public/components/filter/filterFunctions.js
@@ -1,3 +1,4 @@
+
 import {State} from "../../store/State.js";
 import navigateTo from "../../helpers/navigateTo.js";
 

--- a/public/components/filter/toggleHideShow.js
+++ b/public/components/filter/toggleHideShow.js
@@ -1,0 +1,32 @@
+import { eyeFillHide, eyeFillShow } from "../Icons.js"
+
+export default function (e){
+
+    const nodeId = getNodeIdIconType(e).nodeId;
+    const { hide, show } = iconEye(nodeId);
+    const iconType = getNodeIdIconType(e).iconType;
+    const newIcon = iconType === "Show" ? hide : show
+    
+    document.getElementById(`toggleEyeContainer_${nodeId}`).innerHTML = newIcon;
+}
+
+
+export const getNodeIdIconType = (e) => {
+    const targetId = e.target.id.split("_")
+    const buttonType = targetId[0]
+    const nodeId = `${targetId[1]}_${targetId[2]}`
+    const iconType = buttonType.split("toggleEye")[1]
+
+    return {nodeId, iconType}
+}
+
+export const iconEye = (nodeId) => {
+    const iconClass = "text-secondary";
+    const iconMoreConfigShow = `data-function="toggleHideShow" id="toggleEyeShow_${nodeId}" role="button"`;
+    const iconMoreConfigHide = `data-function="toggleHideShow" id="toggleEyeHide_${nodeId}" role="button"`;
+
+    const show = eyeFillShow(iconClass, iconMoreConfigShow);
+    const hide = eyeFillHide(iconClass, iconMoreConfigHide);
+    return { show, hide };
+}
+

--- a/public/helpers/functionRouter.js
+++ b/public/helpers/functionRouter.js
@@ -1,10 +1,13 @@
 import checkFilter, {checkAll} from "../components/filter/filterFunctions.js";
+import toggleHideShow from "../components/filter/toggleHideShow.js";
 
 export default async function (demandedRoute, event) {
     const routes = [
 
         { path: 'checkFilter', request: checkFilter },
-        { path: 'checkAll', request: checkAll }
+        { path: 'checkAll', request: checkAll },
+        { path: 'toggleHideShow', request: toggleHideShow }
+
 
     ];
 


### PR DESCRIPTION
**What’s in?**

- [x]  ~~When hovering a checkbox that is checked, show an eye on left side of checkbox (without moving the checkbox to the side)~~ After discussion with PO> Eye always visible if checkbox is checked + is on the right side
- [x]  ~~when clicking the eye, it changes to a closed eye~~ After discussion with PO>  click on eye --> eye with slash
- [x]  The color should be light grey for both icons (bootstrap color)

**What’s not in?**

Actual functionality of adding/removing nodes

**The ticket is done when:**

We can toggle between opened eye and eye with slash on the right side of label if the checkbox is checked