### PR TITLE
added idKey for relsData, like exist for nodeData

### DIFF
--- a/public/components/graph/Graph.js
+++ b/public/components/graph/Graph.js
@@ -448,7 +448,7 @@ async function Graph(view) {
     link = svg
       .select(".forLinks")
       .selectAll(".linkSVG")
-      .data(rels)
+      .data(rels, (d) => d["id"])
       .join(
         (enter) => {
           const link_enter = enter
@@ -470,9 +470,7 @@ async function Graph(view) {
               }
             });
           return link_enter;
-        },
-        (update) => update
-
+        }
       )
       .join("path")
       .on("click", clicked)
@@ -517,9 +515,6 @@ async function Graph(view) {
             .on("contextmenu", rightClicked)
 
           return entered;
-        },
-        (update) => {
-          return update;
         }
       );
 


### PR DESCRIPTION
added missing key for rels. Without a data key d3 can't identify new rels with old ones. Keys exist for nodes where it works.