### PR TITLE
C2-172 relations between instances dont show up

### DIFF
--- a/public/store/tree/Tree.js
+++ b/public/store/tree/Tree.js
@@ -229,14 +229,16 @@ Tree.prototype.shake = async function () {
     let nodesOnNextLayer = []
 
 
-    for(let i=0; i<3;i++) {
+    for(let i=0; i<=3;i++) {
         for (let node of nodesOnThisLayer) {
             if (node.selected) {
+                if(i<3) {
+                    await node.setChildrenVisibility(this)
+                    node.children.map(child => {
+                        if (child.selected) selectedRels.push(createPseudoParentRel(node.id, child.id))
+                    })
+                }
 
-                await node.setChildrenVisibility(this)
-                node.children.map (child=> {
-                    if(child.selected) selectedRels.push(createPseudoParentRel(node.id, child.id))
-                })
                 const relevantRels = []
                 node.rels.map(rel => {
                     if(rel.sourceId === rel.targetId) relevantRels.push(rel)
@@ -252,6 +254,8 @@ Tree.prototype.shake = async function () {
         nodesOnThisLayer = nodesOnNextLayer
         nodesOnNextLayer = []
     }
+
+
 
     this.setSelectedNodesAndData()
     this.selectedRelations = trimRels(selectedRels, this.selectedTreeNodes)


### PR DESCRIPTION
<!--  Provide the Jira Ticket Title as title above! -->


## Description & motivation

<!-- Describe your changes, and why you're making them -->
Relations between instances did not show up except when artificially selected them (not through the regular intersection process I mean).
There was a loop to modifiy and a condition to set.
In Shake function a loop loop through layers 0-2 to set children visibility and layer rels.
Now it loops once more, thorugh instances, but don't bother for children during this cycle.


## How to test

<!-- Include a step-by-step on how to test the code  -->
Got to filter view, try to show previously created instances rels.


## New tickets to be added

<!-- If you realized, while doing these changes, that new tickets should be added.
(for example, things that could've been added in this PR but were outside of tickets' scope) -->



---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
