### PR TITLE
feat: adjustable context menu (not going out of screen)

### DIFF
--- a/public/components/graph/Graph.js
+++ b/public/components/graph/Graph.js
@@ -236,7 +236,6 @@ async function Graph(view) {
           }
         }
         ReactiveFormCreate();
-        reCalcTopPlacement(d3, ".formCreate");
 
         State.propKeys = [];
         contextMenuItemClick(d3);

--- a/public/components/graph/Graph.js
+++ b/public/components/graph/Graph.js
@@ -19,8 +19,7 @@ import generatePropKeysFromParentIdTypeData from "./graphFunctions/generatePropK
 import contextMenuItemClick from "./graphFunctions/contextMenuItemClick.js";
 import { ReactiveFormCreate } from "./graphComponents/ReactiveFormCreate.js";
 import { FilterBox} from "../filter/FilterBox.js"
-import { checkFilter } from "../filter/filterFunctions.js"
-
+import { reCalcTopPlacement } from "./graphComponents/helpers.js"
 async function Graph(view) {
   State.view = view;
   Actions.GETDEF();
@@ -144,6 +143,7 @@ async function Graph(view) {
           });
         });
       }
+      reCalcTopPlacement(d3, ".contextMenu")
     });
 
   const firstG = svg.append("g").attr("transform", `translate(20,20)`);
@@ -236,6 +236,8 @@ async function Graph(view) {
           }
         }
         ReactiveFormCreate();
+        reCalcTopPlacement(d3, ".formCreate");
+
         State.propKeys = [];
         contextMenuItemClick(d3);
       }
@@ -306,6 +308,8 @@ async function Graph(view) {
       document.getElementById(
         "delete-item"
       ).innerHTML = `- Delete (${State.clickedObj.title})`;
+      reCalcTopPlacement(d3, ".contextMenu")
+
 
       d3.selectAll("#delete-item").on("click", async (e) => {
         await Actions.DELETE(

--- a/public/components/graph/graphComponents/ActivateContextMenu.js
+++ b/public/components/graph/graphComponents/ActivateContextMenu.js
@@ -1,15 +1,20 @@
 import { State } from '../../../store/State.js';
 import ContextMenu from '../ContextMenu.js';
+import { reCalcTopPlacement } from "./helpers.js"
 
 export default function (d3) {
-    d3.select(".FormMenuContainer").remove();
+
     d3.select(".contextMenuContainer").remove();
+    d3.select(".FormMenuContainer").remove();
+    
     event.preventDefault();
-    return d3.select("#app")
+    d3.select("#app")
         .append("div")
         .attr("class", "contextMenuContainer")
         .html(ContextMenu(event, State.clickedObj))
         .select(".contextMenu")
         .style("top", State.clickedObj.clientY + "px")
-        .style("left", State.clickedObj.clientX + "px");
+        .style("left", State.clickedObj.clientX + 50 + "px");
+
+    reCalcTopPlacement(d3, ".contextMenu");
 }

--- a/public/components/graph/graphComponents/ActivateFormEdit.js
+++ b/public/components/graph/graphComponents/ActivateFormEdit.js
@@ -1,6 +1,6 @@
 import { State } from '../../../store/State.js';
 import { FormEdit } from '../FormEdit.js';
-import { reCalcTopPlacement } from "./helpers.js"
+import { moveBoxToTopRight } from "./helpers.js"
 
 export default function (d3) {
     d3.select(".contextMenuContainer").remove();
@@ -11,10 +11,8 @@ export default function (d3) {
         .attr("class", "FormMenuContainer")
         .html(FormEdit(State.clickedObjEvent, State.contextMenuItem, State.clickedObj))
         .select(".formEdit")
-        .style("top", (State.clickedObj.clientY + 10) + "px")
-        .style("left", State.clickedObj.clientX + 50 + "px");
+        .style("top", 70 + "px")
 
-
-        reCalcTopPlacement(d3, ".formEdit")
+        moveBoxToTopRight(d3, ".formEdit")
 
 }

--- a/public/components/graph/graphComponents/ActivateFormEdit.js
+++ b/public/components/graph/graphComponents/ActivateFormEdit.js
@@ -1,15 +1,20 @@
 import { State } from '../../../store/State.js';
 import { FormEdit } from '../FormEdit.js';
+import { reCalcTopPlacement } from "./helpers.js"
 
 export default function (d3) {
     d3.select(".contextMenuContainer").remove();
     d3.select(".FormMenuContainer").remove();
 
-    return d3.select("#root")
+    d3.select("#root")
         .append("div")
         .attr("class", "FormMenuContainer")
         .html(FormEdit(State.clickedObjEvent, State.contextMenuItem, State.clickedObj))
         .select(".formEdit")
         .style("top", (State.clickedObj.clientY + 10) + "px")
-        .style("left", State.clickedObj.clientX + "px");
+        .style("left", State.clickedObj.clientX + 50 + "px");
+
+
+        reCalcTopPlacement(d3, ".formEdit")
+
 }

--- a/public/components/graph/graphComponents/ActivateFormMenu.js
+++ b/public/components/graph/graphComponents/ActivateFormMenu.js
@@ -1,8 +1,9 @@
 import { State } from '../../../store/State.js';
 import { FormCreate } from '../FormCreate.js';
-import { reCalcTopPlacement } from "./helpers.js"
+import { moveBoxToTopRight } from "./helpers.js"
 
 export default function (d3) {
+
     d3.select(".contextMenuContainer").remove();
     d3.select(".FormMenuContainer").remove();
 
@@ -11,8 +12,8 @@ export default function (d3) {
         .attr("class", "FormMenuContainer")
         .html(FormCreate(State.clickedObjEvent, State.contextMenuItem, State.clickedObj))
         .select(".formCreate")
-        .style("top", (State.clickedObj.clientY + 10) + "px")
-        .style("left", State.clickedObj.clientX + 50 + "px");
+        .style("top", 70 + "px")
 
-    reCalcTopPlacement(d3, ".formCreate")
+
+        moveBoxToTopRight(d3, ".formCreate")
 }

--- a/public/components/graph/graphComponents/ActivateFormMenu.js
+++ b/public/components/graph/graphComponents/ActivateFormMenu.js
@@ -1,15 +1,18 @@
 import { State } from '../../../store/State.js';
 import { FormCreate } from '../FormCreate.js';
+import { reCalcTopPlacement } from "./helpers.js"
 
 export default function (d3) {
     d3.select(".contextMenuContainer").remove();
     d3.select(".FormMenuContainer").remove();
 
-    return d3.select("#root")
+    d3.select("#root")
         .append("div")
         .attr("class", "FormMenuContainer")
         .html(FormCreate(State.clickedObjEvent, State.contextMenuItem, State.clickedObj))
         .select(".formCreate")
         .style("top", (State.clickedObj.clientY + 10) + "px")
-        .style("left", State.clickedObj.clientX + "px");
+        .style("left", State.clickedObj.clientX + 50 + "px");
+
+    reCalcTopPlacement(d3, ".formCreate")
 }

--- a/public/components/graph/graphComponents/ActivateFormRead.js
+++ b/public/components/graph/graphComponents/ActivateFormRead.js
@@ -1,15 +1,18 @@
 import { State } from '../../../store/State.js';
 import { FormRead } from '../FormRead.js';
+import { reCalcTopPlacement } from "./helpers.js"
 
 export default function (d3) {
     d3.select(".contextMenuContainer").remove();
     d3.select(".FormMenuContainer").remove();
 
-    return d3.select("#root")
+  d3.select("#root")
         .append("div")
         .attr("class", "FormMenuContainer")
         .html(FormRead(State.clickedObjEvent, State.contextMenuItem, State.clickedObj))
         .select(".formRead")
         .style("top", (State.clickedObj.clientY + 10) + "px")
-        .style("left", State.clickedObj.clientX + "px");
+        .style("left", (State.clickedObj.clientX + 50) + "px");
+    reCalcTopPlacement(d3, ".formRead");
+
 }

--- a/public/components/graph/graphComponents/ActivateFormRead.js
+++ b/public/components/graph/graphComponents/ActivateFormRead.js
@@ -1,6 +1,6 @@
 import { State } from '../../../store/State.js';
 import { FormRead } from '../FormRead.js';
-import { reCalcTopPlacement } from "./helpers.js"
+import { moveBoxToTopRight } from "./helpers.js"
 
 export default function (d3) {
     d3.select(".contextMenuContainer").remove();
@@ -11,8 +11,8 @@ export default function (d3) {
         .attr("class", "FormMenuContainer")
         .html(FormRead(State.clickedObjEvent, State.contextMenuItem, State.clickedObj))
         .select(".formRead")
-        .style("top", (State.clickedObj.clientY + 10) + "px")
-        .style("left", (State.clickedObj.clientX + 50) + "px");
-    reCalcTopPlacement(d3, ".formRead");
+        .style("top", 70 + "px")
 
+
+        moveBoxToTopRight(d3, ".formRead")
 }

--- a/public/components/graph/graphComponents/helpers.js
+++ b/public/components/graph/graphComponents/helpers.js
@@ -7,7 +7,7 @@ export function reCalcTopPlacement(d3, attr) {
     let divBottom = divOffsets.bottom;
 
     let appOffsets = document.querySelector("#app").getBoundingClientRect();
-    let appHeight = appOffsets.height;
+    let appHeight = appOffsets.height; 
 
     if (divBottom > appHeight) {
         let bodyDOM = d3.select(attr).node();
@@ -20,4 +20,14 @@ export function reCalcTopPlacement(d3, attr) {
             .style("left", State.clickedObj.clientX + 50 + "px");
 
     }
+}
+
+
+export function moveBoxToTopRight(d3, attr) {
+
+    let appOffsets = document.querySelector("#app").getBoundingClientRect();
+    let formOffsets = document.querySelector(attr).getBoundingClientRect();
+
+    d3.select(attr)
+    .style("left", appOffsets.width - formOffsets.width - 10 + "px");
 }

--- a/public/components/graph/graphComponents/helpers.js
+++ b/public/components/graph/graphComponents/helpers.js
@@ -1,0 +1,23 @@
+import { State } from '../../../store/State.js';
+
+export function reCalcTopPlacement(d3, attr) {
+    let form = d3.select(attr).node();
+
+    let divOffsets = form.getBoundingClientRect();
+    let divBottom = divOffsets.bottom;
+
+    let appOffsets = document.querySelector("#app").getBoundingClientRect();
+    let appHeight = appOffsets.height;
+
+    if (divBottom > appHeight) {
+        let bodyDOM = d3.select(attr).node();
+        let bodyDOMHeight = bodyDOM.getBoundingClientRect().height;
+
+        let height = appOffsets.height - (bodyDOMHeight + 10 ) + "px";
+
+        d3.select(attr)
+            .style("top", height)
+            .style("left", State.clickedObj.clientX + 50 + "px");
+
+    }
+}


### PR DESCRIPTION
<!--  Provide the Jira Ticket Title as title above! -->


## Description & motivation

<!-- Describe your changes, and why you're making them -->

(Per agreement with PO)

When right click on the canvas, a node or a rel far down, the context menu got outside of the window.

Instead, it is moved so that the context menu is shown + 10 pixels.

When we create, read or update the node/rel, the context menu form moves to the top right corner.

## How to test

<!-- Include a step-by-step on how to test the code  -->

1. Go to the filter view
2. Right click on the canvas (far down)
3. Click on create a def (far down), create one
4. Create another def
5. Create a rel between these defs (far down)
6. Click on a def (far down)
7. Click on a rel (far down)

## New tickets to be added

<!-- If you realized, while doing these changes, that new tickets should be added.
(for example, things that could've been added in this PR but were outside of tickets' scope) -->



---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
