### PR TITLE
keep scrollposition on filterbox repopulation

### DIFF
--- a/public/components/filter/filterFunctions.js
+++ b/public/components/filter/filterFunctions.js
@@ -62,7 +62,7 @@ export async function setFilterBoxCallback(filterBoxNode, redrawData){
                 toggleHideShow(e)
             }
             else return
-
+            const scrollPosition = document.querySelector("#accordion-body-id").scrollTop
             await updateData()
             await redrawData();
             let filterboxBody = document.querySelector("#accordion-body-id")
@@ -70,6 +70,7 @@ export async function setFilterBoxCallback(filterBoxNode, redrawData){
             filterboxBody.innerHTML = await triggerTreeGetHtml()
             setFilterBoxCallback(filterboxBody, redrawData)
             resizeFilterBox()
+            document.querySelector("#accordion-body-id").scrollTop = scrollPosition
     }))
 }
 


### PR DESCRIPTION
<!--  Provide the Jira Ticket Title as title above! -->


## Description & motivation

<!-- Describe your changes, and why you're making them -->
made the filterbox scroll not jump


## How to test

<!-- Include a step-by-step on how to test the code  -->
if you open lots of nodes in filterbox and scroll down.
Then press a node the scroll should not jump to the top.


## New tickets to be added

<!-- If you realized, while doing these changes, that new tickets should be added.
(for example, things that could've been added in this PR but were outside of tickets' scope) -->



---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
