### PR TITLE
C2 189 graph ql when fetching subnodes in query get error nodes resolver is not a function and return null for this field

### DIFF
--- a/api/graphql/graphqlTypes.js
+++ b/api/graphql/graphqlTypes.js
@@ -1,6 +1,6 @@
 const { GraphQLObjectType, GraphQLString } = require("graphql/index");
 const { GraphQLInputObjectType, GraphQLList } = require("graphql/type");
-const { queryNodesResolver, queryRelationshipsResolver, graphResolver, cascadeResolver} = require("./resolvers");
+const { graphResolver, cascadeResolver} = require("./resolvers");
 const { GraphQLEnumType, GraphQLNonNull, GraphQLID, GraphQLInt, GraphQLBoolean} = require("graphql");
 
 const DefinitionType = new GraphQLEnumType({
@@ -71,7 +71,7 @@ const Relationship = new GraphQLObjectType({
                 nodeInput: { type: QueryInput }
             },
             resolve: async (root, args) => {
-                return (await queryNodesResolver(args.nodeInput, { id: root.source, kindOfItem: "node" }))[0]
+                return (await graphResolver(args.nodeInput, { id: root.source, kindOfItem: "node" }))[0]
             }
         },
         targetNode: {
@@ -80,7 +80,7 @@ const Relationship = new GraphQLObjectType({
                 nodeInput: { type: QueryInput }
             },
             resolve: async (root, args) => {
-                return (await queryNodesResolver(args.nodeInput, { id: root.target, kindOfItem: "node" }))[0]
+                return (await graphResolver(args.nodeInput, { id: root.target, kindOfItem: "node" }))[0]
             }
         },
         parentNode: {
@@ -89,7 +89,7 @@ const Relationship = new GraphQLObjectType({
                 relationshipInput: { type: QueryInput }
             },
             resolve: async (root, args) => {
-                return (await queryRelationshipsResolver(args.relationshipInput, { id: root.parentId, kindOfItem: "relationship" }))[0]
+                return (await graphResolver(args.relationshipInput, { id: root.parentId, kindOfItem: "relationship" }))[0]
             }
         },
         created: { type: GraphQLString },
@@ -128,7 +128,7 @@ const Node = new GraphQLObjectType({
                 nodeInput: { type: QueryInput }
             },
             resolve: async (root, args) => {
-                return (await queryNodesResolver(args.nodeInput, { id: root.parentId, kindOfItem: "node" }))[0]
+                return (await graphResolver(args.nodeInput, { id: root.parentId, kindOfItem: "node" }))[0]
             }
         },
         childrenNodes: {
@@ -137,7 +137,7 @@ const Node = new GraphQLObjectType({
                 nodeInput: { type: QueryInput }
             },
             resolve: async (root, args) => {
-                return (await queryNodesResolver(args.nodeInput, { parentId: root.id, kindOfItem: "node" }))
+                return (await graphResolver(args.nodeInput, { parentId: root.id, kindOfItem: "node" }))
             }
         },
         relationships: {

--- a/api/graphql/resolvers.js
+++ b/api/graphql/resolvers.js
@@ -1,5 +1,4 @@
 const { getItems } = require("./dbAccessLayer/crud/read");
-const cascade = require("./dbAccessLayer/helpers/cascade");
 const {voc} = require("./dbAccessLayer/voc");
 
 const definitionTypes = [
@@ -19,26 +18,6 @@ const definitionTypes = [
     "PropKey",
     "PropVal"
 ]
-
-async function itemsResolver(params = {}, enforcedParams = {}) {
-    for (let key in enforcedParams) {
-        if (params[key] !== undefined) console.log(key + " cannot be overwritten in the current context.")
-        params[key] = enforcedParams[key]
-    }
-
-    const items = await getItems(params)
-
-
-    let answer = {}
-    for (let defType of definitionTypes) {
-        answer[defType] = []
-    }
-    for (let item of items) {
-        answer[item.defType].push(item)
-    }
-
-    return answer
-}
 
 async function graphResolver(params = {}, enforcedParams = {}, isUniqueOrNull = false) {
     for (let key in enforcedParams) {


### PR DESCRIPTION
<!--  Provide the Jira Ticket Title as title above! -->


## Description & motivation

<!-- Describe your changes, and why you're making them -->
Using graphql query, it was impossible to fetch subobjects (like a whole new node, fetching primitive fields like ids was fine).
That was because resolver were refactored and these subfields were forgotten. It is now updated.
I also removed a bit of code that was flagged by the ide as unused.


## How to test

<!-- Include a step-by-step on how to test the code  -->
Go to the contechOS frontend, query node in various way -> still works as before.
make a custome query such as 
```
const query = {
        query: `query RooterQueryType($input:QueryInput){
            nodes(itemInput:$input){
                id
                title
                updated
                created
                relationships {
                    id
                    sourceId
                    sourceNode {
                        id
                        title
                    }
                 }
            }
        }`,
        variables: {
input: { defType: "configDef"}
        }
    }
```

The sourceNode field will not be null if the target of some relation.


## New tickets to be added

<!-- If you realized, while doing these changes, that new tickets should be added.
(for example, things that could've been added in this PR but were outside of tickets' scope) -->



---
- [x] The ticket is done, OR it's been mentioned why it's not done above

- [x] Removed console.log in code

- [x] Pulled dev into this branch

- [x] Resolved merge conflicts

- [x] The ID of branch is of format "ABC-123"

- [x] Added a reviewer
